### PR TITLE
Add generic deriving

### DIFF
--- a/lub.cabal
+++ b/lub.cabal
@@ -32,7 +32,7 @@ source-repository head
 Library
   hs-Source-Dirs:      src
   Extensions:
-  Build-Depends:       base < 5, unamb >= 0.2.4
+  Build-Depends:       base >= 4.6 && < 5, unamb >= 0.2.4
   Exposed-Modules:     
                        Data.Repr
                        Data.Lub

--- a/src/Data/Glb.hs
+++ b/src/Data/Glb.hs
@@ -1,4 +1,16 @@
--- {-# LANGUAGE #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE EmptyCase #-}
+#endif
+
 {-# OPTIONS_GHC -Wall #-}
 ----------------------------------------------------------------------
 -- |
@@ -12,17 +24,34 @@
 -- Greatest lower bound
 ----------------------------------------------------------------------
 
-module Data.Glb (HasGlb(..),glbBottom,flatGlb) where
+module Data.Glb (HasGlb(..),glbBottom,flatGlb
+  , GHasGlb
+  , genericGlb
+  ) where
 
-import Control.Applicative (liftA2)
+import Control.Applicative (liftA2, Const)
 
-import Data.Repr
+import GHC.Generics
+
+#if MIN_VERSION_base(4,8,0)
+import qualified Data.Functor.Identity as Identity
+import qualified Data.Void as Void
+#endif
+#if MIN_VERSION_base(4,9,0)
+import qualified Data.Functor.Compose as Compose
+import qualified Data.Functor.Product as Product
+import qualified Data.Functor.Sum as Sum
+#endif
+
 
 -- | Types that support information intersection ('glb')
 class HasGlb a where
   -- | Greatest lower information bound.  Intersects information available
   -- from each argument.
   glb  :: a -> a -> a
+  default glb :: (Generic a, GHasGlb (Rep a)) => a -> a -> a
+  glb = genericGlb
+
   -- | n-ary 'glb' for n > 0.  Defaults to @foldr1 glb@.  Unlike @lub@, we
   -- have no unit for 'glb'.
   glbs1 :: [a] -> a
@@ -40,8 +69,6 @@ flatGlb a b | a == b    = a
             | otherwise = glbBottom "flat & unequal"
 
 -- Flat types:
-instance HasGlb ()      where glb = flatGlb
-instance HasGlb Bool    where glb = flatGlb
 instance HasGlb Char    where glb = flatGlb
 instance HasGlb Int     where glb = flatGlb
 instance HasGlb Integer where glb = flatGlb
@@ -49,28 +76,40 @@ instance HasGlb Float   where glb = flatGlb
 instance HasGlb Double  where glb = flatGlb
 -- ...
 
-instance (HasGlb a, HasGlb b) => HasGlb (a,b) where
-  (a,b) `glb` (a',b') = (a `glb` a', b `glb` b')
+-- Generic-derived instances
+instance HasGlb ()
+instance HasGlb Bool
+instance (HasGlb a, HasGlb b) => HasGlb (Either a b)
+instance HasGlb a => HasGlb (Maybe a)
+instance HasGlb a => HasGlb [a]
 
+instance (HasGlb a, HasGlb b) => HasGlb (a, b)
+instance (HasGlb a, HasGlb b, HasGlb c) => HasGlb (a, b, c)
+instance (HasGlb a, HasGlb b, HasGlb c, HasGlb d) => HasGlb (a, b, c, d)
+instance (HasGlb a, HasGlb b, HasGlb c, HasGlb d, HasGlb e) => HasGlb (a, b, c, d, e)
+
+instance HasGlb a => HasGlb (Const a b)
+
+#if MIN_VERSION_base(4,8,0)
+instance HasGlb a => HasGlb (Identity.Identity a)
+instance HasGlb Void.Void
+#endif
+
+-- People often use :+: and :*: rather than Sum and Product
+-- even outside of a Generic context.
+instance (HasGlb (f a), HasGlb (g a)) => HasGlb ((f :*: g) a)
+instance (HasGlb (f a), HasGlb (g a)) => HasGlb ((f :+: g) a)
+
+#if MIN_VERSION_base(4,9,0)
+instance HasGlb (f (g a)) => HasGlb (Compose.Compose f g a)
+instance (HasGlb (f a), HasGlb (g a)) => HasGlb (Product.Product f g a)
+instance (HasGlb (f a), HasGlb (g a)) => HasGlb (Sum.Sum f g a)
+#endif
+
+
+-- Functions
 instance HasGlb b => HasGlb (a -> b) where
   glb = liftA2 glb
-
-instance (HasGlb a, HasGlb b) => HasGlb (Either a b) where
-  Left  a `glb` Left  a' = Left  (a `glb` a')
-  Right b `glb` Right b' = Right (b `glb` b')
-  _ `glb` _ = glbBottom "Left/Right mismatch"
-
-
--- 'glb' on representations
-repGlb :: (HasRepr a v, HasGlb v) => a -> a -> a
-repGlb = onRepr2 glb
-
--- instance (HasRepr t v, HasGlb v) => HasGlb t where
---   glb = repGlb
-
--- For instance,
-instance HasGlb a => HasGlb (Maybe a) where glb = repGlb
-instance HasGlb a => HasGlb [a]       where glb = repGlb
 
 {- -- Examples
 
@@ -91,3 +130,76 @@ t5 = [2,3,5] `glb` [1,3]  -- _|_:3:_|_
 
 -}
 
+-- | Used for generic deriving of 'HasGlb'
+class GHasGlb f where
+  gglb :: (Generic a, Rep a ~ f) => a -> a -> a
+
+-- | A suitable definition of 'glb' for instances of 'Generic'.
+genericGlb :: (Generic a, GHasGlb (Rep a)) => a -> a -> a
+-- What makes genericGlb different from gglb? When using
+-- TypeApplications, the first type argument of gglb is
+-- the representation type; that's not very friendly.
+genericGlb a b = gglb a b
+
+-- Newtypes don't want their outsides forced/checked, because they don't have any.
+instance HasGlb x => GHasGlb (D1 ('MetaData _q _r _s 'True) (C1 _t (S1 _u (K1 _v x)))) where
+  gglb a b
+    | M1 (M1 (M1 (K1 x))) <- from a
+    , M1 (M1 (M1 (K1 y))) <- from b
+    = to (M1 (M1 (M1 (K1 (glb x y)))))
+
+-- Not a newtype, but possibly a lifted unary tuple.
+-- We force the outsides first in case that is so.
+instance GHasGlb' f => GHasGlb (D1 ('MetaData _q _r _s 'False) f) where
+  gglb !a !b
+    = to (M1 (gglb' ar br))
+    where
+      M1 ar = from a
+      M1 br = from b
+
+-- | Used for non-newtype 'Generic' deriving.
+class GHasGlb' f where
+  gglb' :: f p -> f p -> f p
+
+instance GHasGlb' f => GHasGlb' (M1 i c f) where
+  gglb' (M1 l) (M1 r) = M1 (gglb' l r)
+
+instance (GHasGlb' f, GHasGlb' g, HasCon f, HasCon g) => GHasGlb' (f :+: g) where
+  gglb' (L1 l1) (L1 l2) = L1 (gglb' l1 l2)
+  gglb' (R1 r1) (R1 r2) = R1 (gglb' r1 r2)
+
+  gglb' (L1 l1) (R1 r2) = mismatchedCons (getConName l1) (getConName r2)
+  gglb' (R1 r1) (L1 l2) = mismatchedCons (getConName r1) (getConName l2)
+
+class HasCon f where
+  getConName :: f p -> String
+instance Constructor i => HasCon (C1 i f) where
+  getConName = conName
+instance (HasCon f, HasCon g) => HasCon (f :+: g) where
+  getConName (L1 x) = getConName x
+  getConName (R1 x) = getConName x
+
+mismatchedCons :: String -> String -> a
+mismatchedCons l r = glbBottom $
+    "Mismatched constructors.\nThe left argument was built with "
+    ++ l ++ ",\nbut the right one was built with " ++ r ++ "."
+
+instance (GHasGlb' f, GHasGlb' g) => GHasGlb' (f :*: g) where
+  gglb' (l1 :*: l2) (r1 :*: r2) =
+    gglb' l1 r1 :*: gglb' l2 r2
+
+instance GHasGlb' U1 where
+  -- We pattern match strictly so we don't get
+  --
+  -- glb @() () undefined = ()
+  gglb' U1 U1 = U1
+
+instance GHasGlb' V1 where
+#if __GLASGOW_HASKELL__ >= 708
+  gglb' v _ = case v of
+#else
+  gglb' !_ _ = error "Can't happen"
+#endif
+
+instance HasGlb c => GHasGlb' (K1 i c) where
+  gglb' (K1 l) (K1 r) = K1 $ glb l r

--- a/src/Data/Lub.hs
+++ b/src/Data/Lub.hs
@@ -224,19 +224,7 @@ zip' (1 : 2 : error "boom") [10,20]
 
 Alternatively, we can avoid the constraints and partial matches
 by using lub only to (lazily) calculate the *length* of the
-result:
-
-fairZipWith :: (a -> b -> c) -> [a] -> [b] -> [c]
-fairZipWith' f as bs =
-  zipWith3
-    (const f)
-    (lub (zipWith discard as bs) (zipWith discard bs as))
-    as
-    bs
-  where
-    discard _ _ = ()
-
-Unlike zipWith, `flip . fairZipWith = fairZipWith . flip`.
+result. See Data.Laxer.fairZipWith and fairZip.
 -}
 
 -- ------------------------

--- a/src/Data/Lub.hs
+++ b/src/Data/Lub.hs
@@ -175,6 +175,10 @@ zip' (1 : 2 : error "boom") [10,20]
 
 -- | Used for generic deriving of 'HasLub'
 class GHasLub f where
+  -- Yes, this is an unusual type for the method of a class of Generic
+  -- representations. But we need to make decisions about what we do with `a`
+  -- itself based on what its representation looks like, and this seems
+  -- to be the simplest way to achieve that by far.
   glub :: (Generic a, Rep a ~ f) => a -> a -> a
 
 -- | A suitable definition of 'lub' for instances of 'Generic'.

--- a/src/Data/Repr.hs
+++ b/src/Data/Repr.hs
@@ -16,7 +16,8 @@
 -- This version uses associated types for HasRepr
 ----------------------------------------------------------------------
 
-module Data.Repr (HasRepr(..), onRepr, onRepr2) where
+module Data.Repr {-# DEPRECATED "Use generics instead" #-}
+  (HasRepr(..), onRepr, onRepr2) where
 
 -- Reprs.  TODO: find & use a simple, standard generic programming framework.
 


### PR DESCRIPTION
* Add a `GHasLub` class and `genericLub` function for generic
  definitions of `lub`, and use it to provide a default
  definition of `lub` using `DefaultSignatures`.

* Use the generic default for the `Maybe a`, `Either a b`, `(a, b)`,
  and `[a]` instances. Add generic-derived instances for tuples of
  size up to five.